### PR TITLE
fix waitKey bug

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -233,7 +233,7 @@ int main(int argc, char* argv[])
 		if (!conf.quietMode)
 		{
 			imshow("result", result);
-			int key = waitKey(paused ? 0 : 1);
+			int key = waitKey(paused ? 0 : 1) % 256; //modulo 256 to retrieve last 8 bits only, known OpenCV bug
 			if (key != -1)
 			{
 				if (key == 27 || key == 113) // esc q


### PR DESCRIPTION
waitKey returns weird results.
Results such as:
http://stackoverflow.com/questions/9172170/python-opencv-cv-waitkey-spits-back-weird-output-on-ubuntu-modulo-256-maps-corre

My platform is Raspberry Pi 3 Model B running Raspbian Jessie.

And fix is to retrieve last 8 bits only.
`key & 255` works but removes the sign, so `key % 256` is used instead.
